### PR TITLE
fix: update Dockerfile to use npm install instead of npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install --production=false
 
 # Copy source code
 COPY src ./src


### PR DESCRIPTION
This pull request makes a small change to the Docker build process by switching the dependency installation command from `npm ci` to `npm install --production=false`. This may affect how dependencies are installed in the Docker image.