### PR TITLE
docs: update quickstart to specify version in .env file

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1130,9 +1130,9 @@ TELEGRAM_ENABLED=false
 
 To pin to a specific version instead of `latest`:
 
-**Docker Compose** - Edit `docker-compose.yml`:
-```yaml
-image: ghcr.io/ramen4598/notion2wordpress:v1.0.0
+**.env** - Edit `.env`:
+```
+N2W_VERSION=1.0.0
 ```
 
 **Docker Run:**


### PR DESCRIPTION
This pull request updates the documentation to clarify how to specify the application version when deploying with Docker. Instead of editing the `docker-compose.yml` file directly, users are now instructed to set the version in the `.env` file.

Documentation update:

* Updated `docs/quickstart.md` to instruct users to set the `N2W_VERSION` variable in the `.env` file instead of editing the `docker-compose.yml` for version pinning.