### PR TITLE
fix: log full error object on Telegram notification failure

### DIFF
--- a/src/services/telegramService.ts
+++ b/src/services/telegramService.ts
@@ -61,7 +61,7 @@ class TelegramService {
       });
       logger.info(`Sent Telegram notification${append}`);
     } catch (error : unknown) {
-      logger.error(`Failed to send Telegram notification${append}`, asError(error).message);
+      logger.error(`Failed to send Telegram notification${append}`, asError(error));
       // Don't throw - notification failures shouldn't block the sync
     }
   }


### PR DESCRIPTION
This pull request makes a minor improvement to the error logging in the `TelegramService`. Instead of logging only the error message when a Telegram notification fails to send, it now logs the entire error object, which will provide more context for debugging.