### PR TITLE
feat: Add WordPress URL to Telegram notification messages

### DIFF
--- a/src/services/telegramService.ts
+++ b/src/services/telegramService.ts
@@ -86,6 +86,7 @@ class TelegramService {
    */
   private formatTextMessage(text: string): string {
     let message = '⚠️ *Notification*\n\n';
+    message += `*URL:* ${this.getDomain()}\n\n`;
     message += this.truncateText(text) + '\n';
     message += `*Check logs for full error details*`;
     return message;
@@ -104,6 +105,7 @@ class TelegramService {
     const statusText = status === JobStatus.Completed ? 'Completed' : 'Failed';
 
     let message = `${emoji} *Notion→WordPress Sync ${statusText}*\n\n`;
+    message += `*URL:* ${this.getDomain()}\n\n`;
     message += `*Job ID:* ${jobId}\n`;
     message += `*Type:* ${jobType}\n`;
     message += `*Pages Processed:* ${pagesProcessed}\n`;
@@ -128,6 +130,15 @@ class TelegramService {
     }
 
     return message;
+  }
+
+  /**   
+   * Extracts the domain from the WordPress API URL.
+   * @returns Domain string.
+   */
+  private getDomain(): string {
+    const url = new URL(config.wpApiUrl);
+    return url.hostname;
   }
 
   /**


### PR DESCRIPTION
This pull request enhances the Telegram notification messages by including the domain name in both error and job status messages. It does so by introducing a new helper method to extract the domain from the configured WordPress API URL.

Improvements to Telegram notifications:

* Added the domain (extracted from `config.wpApiUrl`) to the formatted error notification messages by updating the `formatTextMessage` method.
* Included the domain in the job status messages (completed or failed) by updating the relevant message formatting logic.

Codebase enhancements:

* Introduced a new private `getDomain` method in `TelegramService` to extract and return the domain from the WordPress API URL.